### PR TITLE
Discord: add `replyToMessage`, logging to example, and scaffold tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ lazy val `chatops4s-discord-example` = (project in file("chatops4s-discord-examp
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.softwaremill.sttp.tapir" %% "tapir-http4s-server"    % "1.11.36",
+      "ch.qos.logback" % "logback-classic" % "1.5.18",
+      "com.softwaremill.sttp.tapir" %% "tapir-http4s-server"    % "1.11.37",
       "org.http4s" %% "http4s-blaze-server"                     % "0.23.17",
       "com.softwaremill.sttp.client4" %% "cats"                 % "4.0.9",
     ),
@@ -20,10 +21,10 @@ lazy val `chatops4s-discord` = (project in file("chatops4s-discord"))
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.softwaremill.sttp.tapir" %% "tapir-core"             % "1.11.36",
-      "com.softwaremill.sttp.tapir" %% "tapir-cats"             % "1.11.36",
+      "com.softwaremill.sttp.tapir" %% "tapir-core"             % "1.11.37",
+      "com.softwaremill.sttp.tapir" %% "tapir-cats"             % "1.11.37",
       "org.bouncycastle" % "bcpkix-jdk15on"                     % "1.70",
-      "com.softwaremill.sttp.tapir" %% "tapir-json-circe"       % "1.11.36",
+      "com.softwaremill.sttp.tapir" %% "tapir-json-circe"       % "1.11.37",
       "com.softwaremill.sttp.client4" %% "core"                 % "4.0.9",
       "com.softwaremill.sttp.client4" %% "circe"                % "4.0.9",
       "io.circe" %% "circe-parser"                              % "0.14.14",

--- a/chatops4s-discord-example/src/main/resources/logback.xml
+++ b/chatops4s-discord-example/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="org.business4s.chatops4s-discord-example" level="DEBUG" />
+</configuration>

--- a/chatops4s-discord-example/src/main/resources/logback.xml
+++ b/chatops4s-discord-example/src/main/resources/logback.xml
@@ -1,11 +1,11 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="INFO">
+
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="org.business4s.chatops4s-discord-example" level="DEBUG" />
 </configuration>

--- a/chatops4s-discord-example/src/main/scala/services/SendToProductionService.scala
+++ b/chatops4s-discord-example/src/main/scala/services/SendToProductionService.scala
@@ -15,7 +15,7 @@ class SendToProductionService(discordOutbound: DiscordOutbound) extends StrictLo
         ),
       )
       .flatMap { response =>
-        IO.println(s"Accepted. Sent message ${response.messageId}")
+        IO.pure(logger.info(s"Accepted. Sent message ${response.messageId}"))
       }
   }
 
@@ -28,7 +28,7 @@ class SendToProductionService(discordOutbound: DiscordOutbound) extends StrictLo
         ),
       )
       .flatMap { response =>
-        IO.println(s"Declined. Sent message ${response.messageId}")
+        IO.pure(logger.info(s"Declined. Sent message ${response.messageId}"))
       }
   }
 }

--- a/chatops4s-discord/src/main/scala/api/DiscordOutbound.scala
+++ b/chatops4s-discord/src/main/scala/api/DiscordOutbound.scala
@@ -3,7 +3,7 @@ package api
 import io.circe.*
 import io.circe.syntax.*
 import cats.effect.IO
-import com.typesafe.scalalogging.{Logger, StrictLogging}
+import com.typesafe.scalalogging.StrictLogging
 import enums.{ButtonStyle, ContentType}
 import models.*
 import sttp.client4.circe.asJson

--- a/chatops4s-discord/src/main/scala/api/Server.scala
+++ b/chatops4s-discord/src/main/scala/api/Server.scala
@@ -1,7 +1,7 @@
 package api
 
 import cats.effect.IO
-import com.typesafe.scalalogging.{Logger, StrictLogging}
+import com.typesafe.scalalogging.StrictLogging
 import enums.InteractionType
 import io.circe.Json
 import io.circe.parser.*

--- a/chatops4s-discord/src/main/scala/models/OutboundGateway.scala
+++ b/chatops4s-discord/src/main/scala/models/OutboundGateway.scala
@@ -4,5 +4,5 @@ import cats.effect.IO
 
 trait OutboundGateway {
   def sendToChannel(channelId: String, message: Message): IO[MessageResponse]
-  def sendToThread(messageId: String, message: Message): IO[MessageResponse]
+  def replyToMessage(channelId: String, messageId: String, message: Message): IO[MessageResponse]
 }

--- a/chatops4s-discord/src/test/scala/api/DiscordInboundTest.scala
+++ b/chatops4s-discord/src/test/scala/api/DiscordInboundTest.scala
@@ -1,0 +1,12 @@
+package api
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class DiscordInboundTest extends AnyFreeSpec with Matchers {
+  "DiscordInbound" - {
+    "register an interaction" in {
+      assert(true)
+    }
+  }
+}

--- a/chatops4s-discord/src/test/scala/api/DiscordOutboundTest.scala
+++ b/chatops4s-discord/src/test/scala/api/DiscordOutboundTest.scala
@@ -1,0 +1,15 @@
+package api
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class DiscordOutboundTest extends AnyFreeSpec with Matchers {
+  "DiscordOutbound" - {
+    "send to a channel" in {
+      assert(true)
+    }
+    "send to a thread" in {
+      assert(true)
+    }
+  }
+}

--- a/chatops4s-discord/src/test/scala/api/ServerTest.scala
+++ b/chatops4s-discord/src/test/scala/api/ServerTest.scala
@@ -1,0 +1,12 @@
+package api
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ServerTest extends AnyFreeSpec with Matchers {
+  "Sever" - {
+    "interactionRoute works" in {
+      assert(true)
+    }
+  }
+}


### PR DESCRIPTION
- User can use the `replyToMessage` to send a message in reply to another.
- By using `replyToMessage` a user can send a confirmation message and reply/refer to the original accept/decline message.
- Scaffold tests with `scalatest`