### PR TITLE
Discord: Add support for creating and sending in threads

### DIFF
--- a/chatops4s-discord-example/src/main/scala/Main.scala
+++ b/chatops4s-discord-example/src/main/scala/Main.scala
@@ -14,8 +14,9 @@ import io.circe.generic.auto.*
 import sttp.client4.httpclient.cats.HttpClientCatsBackend
 
 object Main extends IOApp {
-  private val server         = new Server(discordPublicKey = "cec2f053ddcba6bb67570ac176afc730df3325a729ccb32edbed9dbe4d1741ca")
   private val discordInbound = new DiscordInbound()
+  private val server         =
+    new Server(discordPublicKey = "cec2f053ddcba6bb67570ac176afc730df3325a729ccb32edbed9dbe4d1741ca", discordInbound = discordInbound)
 
   private val sendEndpoint = endpoint.get
     .in("send")

--- a/chatops4s-discord-example/src/main/scala/services/SendToProductionService.scala
+++ b/chatops4s-discord-example/src/main/scala/services/SendToProductionService.scala
@@ -7,16 +7,15 @@ import models.Message
 
 class SendToProductionService(discordOutbound: DiscordOutbound) extends StrictLogging {
   def onAccept(channelId: String): IO[Unit] = {
-    discordOutbound
-      .sendToChannel(
-        channelId,
-        Message(
-          text = "Sending to production!",
-        ),
+    discordOutbound.sendToThread(
+      channelId = channelId,
+      threadName = "Test Thread!",
+      message = Message(
+        text = "Sending to production!",
       )
-      .flatMap { response =>
-        IO.pure(logger.info(s"Accepted. Sent message ${response.messageId}"))
-      }
+    ).flatMap { response =>
+      IO.pure(logger.info(s"Accepted. Sent message ${response.messageId}"))
+    }
   }
 
   def onDecline(channelId: String): IO[Unit] = {

--- a/chatops4s-discord/src/main/scala/api/Server.scala
+++ b/chatops4s-discord/src/main/scala/api/Server.scala
@@ -16,11 +16,10 @@ import org.bouncycastle.util.encoders.Hex
 import sttp.model.StatusCode
 import sttp.tapir.server.ServerEndpoint.Full
 
-class Server(discordPublicKey: String) extends StrictLogging {
+class Server(discordPublicKey: String, discordInbound: DiscordInbound) extends StrictLogging {
   sealed trait ErrorInfo
   private case class BadRequest(what: String) extends ErrorInfo
   private case class Unauthorized()           extends ErrorInfo
-  private val discordInbound = new DiscordInbound()
 
   private val interactionEndpoint =
     endpoint.post

--- a/chatops4s-discord/src/main/scala/models/OutboundGateway.scala
+++ b/chatops4s-discord/src/main/scala/models/OutboundGateway.scala
@@ -4,5 +4,6 @@ import cats.effect.IO
 
 trait OutboundGateway {
   def sendToChannel(channelId: String, message: Message): IO[MessageResponse]
+  def sendToThread(channelId: String, threadName: String, message: Message): IO[MessageResponse]
   def replyToMessage(channelId: String, messageId: String, message: Message): IO[MessageResponse]
 }


### PR DESCRIPTION
- Add `sendToThread` api
- User can name a thread and send a message once it is created