### PR TITLE
make `buildBlocks` method public in `FormDef` trait

### DIFF
--- a/chatops4s-slack/src/main/scala/chatops4s/slack/form.scala
+++ b/chatops4s-slack/src/main/scala/chatops4s/slack/form.scala
@@ -331,7 +331,7 @@ object FieldCodec {
 trait FormDef[T] {
   def fields: List[FormFieldDef]
   def parse(values: Map[String, Map[String, ViewStateValue]]): Either[String, T]
-  private[slack] def buildBlocks(initialValues: Map[String, Any]): List[Block]
+  def buildBlocks(initialValues: Map[String, Any]): List[Block]
 }
 
 object FormDef {
@@ -357,7 +357,7 @@ object FormDef {
         }
       }
 
-      private[slack] def buildBlocks(initialValues: Map[String, Any]): List[Block] =
+      def buildBlocks(initialValues: Map[String, Any]): List[Block] =
         fieldsAndCodecs.map { case (fieldDef, _, buildElementFn) =>
           val iv      = initialValues.get(fieldDef.id)
           val element = buildElementFn(fieldDef.id, iv)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API accessibility for form generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->