### PR TITLE
Add support for tracking required bot scopes in `IdempotencyCheck` 

### DIFF
--- a/chatops4s-slack-client/src/main/scala/chatops4s/slack/api/SlackApi.scala
+++ b/chatops4s-slack-client/src/main/scala/chatops4s/slack/api/SlackApi.scala
@@ -10,7 +10,7 @@ import chatops4s.slack.api.chat.{
   UpdateRequest,
   UpdateResponse,
 }
-import chatops4s.slack.api.conversations.{HistoryRequest, HistoryResponse, RepliesRequest, RepliesResponse}
+import chatops4s.slack.api.conversations.{HistoryRequest, HistoryResponse, ListRequest, ListResponse, RepliesRequest, RepliesResponse}
 import chatops4s.slack.api.reactions.{AddRequest, AddResponse, RemoveRequest, RemoveResponse}
 import chatops4s.slack.api.users.{InfoRequest as UsersInfoRequest, InfoResponse as UsersInfoResponse}
 import chatops4s.slack.api.views.{OpenRequest, OpenResponse}
@@ -61,6 +61,9 @@ class SlackApi[F[_]](backend: Backend[F], token: SlackBotToken) {
 
     // https://docs.slack.dev/reference/methods/conversations.replies
     def replies(req: RepliesRequest): F[SlackResponse[RepliesResponse]] = post("conversations.replies", req)
+
+    // https://docs.slack.dev/reference/methods/conversations.list
+    def list(req: ListRequest): F[SlackResponse[ListResponse]] = post("conversations.list", req)
   }
 
   object users {

--- a/chatops4s-slack-client/src/main/scala/chatops4s/slack/api/models.scala
+++ b/chatops4s-slack-client/src/main/scala/chatops4s/slack/api/models.scala
@@ -282,6 +282,7 @@ object chat {
 
 case class ResponseMetadata(
     messages: Option[List[String]] = None,
+    next_cursor: Option[String] = None,
 ) derives Codec.AsObject
 
 object reactions {
@@ -407,6 +408,24 @@ object conversations {
   case class RepliesResponse(
       messages: List[Message],
       has_more: Option[Boolean] = None,
+      response_metadata: Option[ResponseMetadata] = None,
+  ) derives Codec.AsObject
+
+  case class ListRequest(
+      limit: Option[Int] = None,
+      cursor: Option[String] = None,
+      types: Option[String] = None,
+      exclude_archived: Option[Boolean] = None,
+  ) derives Codec.AsObject
+
+  case class ConversationInfo(
+      id: ChannelId,
+      name: Option[String] = None,
+      is_archived: Option[Boolean] = None,
+  ) derives Codec.AsObject
+
+  case class ListResponse(
+      channels: List[ConversationInfo],
       response_metadata: Option[ResponseMetadata] = None,
   ) derives Codec.AsObject
 }

--- a/chatops4s-slack/src/main/scala/chatops4s/slack/IdempotencyCheck.scala
+++ b/chatops4s-slack/src/main/scala/chatops4s/slack/IdempotencyCheck.scala
@@ -129,8 +129,8 @@ object IdempotencyCheck {
               }
               messagesF.map { messages =>
                 messages.collectFirst {
-                  case msg if msg.metadata.exists(m => extractKeyFromMetadata(m).contains(key.value)) =>
-                    MessageId(channelId, msg.ts.getOrElse(Timestamp("")))
+                  case msg if msg.ts.isDefined && msg.metadata.exists(m => extractKeyFromMetadata(m).contains(key.value)) =>
+                    MessageId(channelId, msg.ts.get)
                 }
               }
           }

--- a/chatops4s-slack/src/main/scala/chatops4s/slack/IdempotencyCheck.scala
+++ b/chatops4s-slack/src/main/scala/chatops4s/slack/IdempotencyCheck.scala
@@ -8,8 +8,9 @@ import sttp.monad.syntax.*
 import java.time.{Duration, Instant}
 
 trait IdempotencyCheck[F[_]] {
-  def findExisting(channel: ChannelId, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]]
+  def findExisting(channel: String, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]]
   def recordSent(key: IdempotencyKey, messageId: MessageId): F[Unit]
+  def requiredBotScopes: Set[String] = Set.empty
 }
 
 object IdempotencyCheck {
@@ -18,9 +19,9 @@ object IdempotencyCheck {
 
   def noCheck[F[_]](using monad: MonadError[F]): IdempotencyCheck[F] =
     new IdempotencyCheck[F] {
-      def findExisting(channel: ChannelId, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]] =
+      def findExisting(channel: String, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]] =
         monad.unit(None)
-      def recordSent(key: IdempotencyKey, messageId: MessageId): F[Unit]                                           =
+      def recordSent(key: IdempotencyKey, messageId: MessageId): F[Unit]                                        =
         monad.unit(())
     }
 
@@ -74,7 +75,7 @@ object IdempotencyCheck {
   )(using monad: MonadError[F])
       extends IdempotencyCheck[F] {
 
-    def findExisting(channel: ChannelId, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]] =
+    def findExisting(channel: String, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]] =
       ref.get.map { entries =>
         entries.get(key).collect {
           case entry if !isExpired(entry) => entry.messageId
@@ -105,21 +106,42 @@ object IdempotencyCheck {
   )(using monad: MonadError[F])
       extends IdempotencyCheck[F] {
 
-    def findExisting(channel: ChannelId, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]] =
+    override val requiredBotScopes: Set[String] =
+      Set(
+        "channels:history",
+        "groups:history",
+        "mpim:history",
+        "im:history",
+        "channels:read",
+        "groups:read",
+      )
+
+    def findExisting(channel: String, threadTs: Option[Timestamp], key: IdempotencyKey): F[Option[MessageId]] =
       clientRef.get.flatMap {
         case None         => monad.unit(None)
         case Some(client) =>
-          val messagesF = threadTs match {
-            case Some(ts) => client.fetchThreadReplies(channel, ts, scanLimit)
-            case None     => client.fetchRecentMessages(channel, scanLimit)
-          }
-          messagesF.map { messages =>
-            messages.collectFirst {
-              case msg if msg.metadata.exists(m => extractKeyFromMetadata(m).contains(key.value)) =>
-                MessageId(channel, msg.ts.getOrElse(Timestamp("")))
-            }
+          resolveChannelId(client, channel).flatMap {
+            case None            => monad.unit(None)
+            case Some(channelId) =>
+              val messagesF = threadTs match {
+                case Some(ts) => client.fetchThreadReplies(channelId, ts, scanLimit)
+                case None     => client.fetchRecentMessages(channelId, scanLimit)
+              }
+              messagesF.map { messages =>
+                messages.collectFirst {
+                  case msg if msg.metadata.exists(m => extractKeyFromMetadata(m).contains(key.value)) =>
+                    MessageId(channelId, msg.ts.getOrElse(Timestamp("")))
+                }
+              }
           }
       }
+
+    private def resolveChannelId(client: SlackClient[F], channel: String): F[Option[ChannelId]] =
+      if (looksLikeChannelId(channel)) monad.unit(Some(ChannelId(channel)))
+      else client.findChannelIdByName(channel)
+
+    private def looksLikeChannelId(s: String): Boolean =
+      s.nonEmpty && (s.head == 'C' || s.head == 'G' || s.head == 'D') && s.forall(c => c.isUpper || c.isDigit)
 
     def recordSent(key: IdempotencyKey, messageId: MessageId): F[Unit] =
       monad.unit(())

--- a/chatops4s-slack/src/main/scala/chatops4s/slack/SlackClient.scala
+++ b/chatops4s-slack/src/main/scala/chatops4s/slack/SlackClient.scala
@@ -25,7 +25,7 @@ import chatops4s.slack.monadSyntax.*
 
 private[slack] class SlackClient[F[_]](token: SlackBotToken, backend: Backend[F]) {
 
-  private given sttp.monad.MonadError[F] = backend.monad
+  private given monad: sttp.monad.MonadError[F] = backend.monad
 
   private val api = new SlackApi[F](backend, token)
 
@@ -125,5 +125,30 @@ private[slack] class SlackClient[F[_]](token: SlackBotToken, backend: Backend[F]
       include_all_metadata = Some(true),
     )
     api.conversations.replies(request).map(_.okOrThrow.messages)
+  }
+
+  def findChannelIdByName(name: String): F[Option[ChannelId]] = {
+    val needle = name.stripPrefix("#")
+
+    def loop(cursor: Option[String]): F[Option[ChannelId]] = {
+      val req = conversations.ListRequest(
+        limit = Some(200),
+        cursor = cursor,
+        types = Some("public_channel,private_channel"),
+        exclude_archived = Some(true),
+      )
+      api.conversations.list(req).map(_.okOrThrow).flatMap { resp =>
+        resp.channels.find(_.name.contains(needle)).map(_.id) match {
+          case Some(id) => monad.unit(Some(id))
+          case None     =>
+            resp.response_metadata.flatMap(_.next_cursor).filter(_.nonEmpty) match {
+              case Some(next) => loop(Some(next))
+              case None       => monad.unit(None)
+            }
+        }
+      }
+    }
+
+    loop(None)
   }
 }

--- a/chatops4s-slack/src/main/scala/chatops4s/slack/SlackGatewayImpl.scala
+++ b/chatops4s-slack/src/main/scala/chatops4s/slack/SlackGatewayImpl.scala
@@ -94,12 +94,18 @@ private[slack] class SlackGatewayImpl[F[_]](
 
   override def manifest(appName: String): F[SlackAppManifest] = {
     for {
-      handlers <- handlersRef.get
-      commands <- commandHandlersRef.get
-      forms    <- formHandlersRef.get
+      handlers    <- handlersRef.get
+      commands    <- commandHandlersRef.get
+      forms       <- formHandlersRef.get
+      idempotency <- idempotencyRef.get
     } yield {
       val commandDefs = commands.map((name, entry) => name.value -> (entry.description, entry.usageHint))
-      SlackManifest.generate(appName, commandDefs, hasInteractivity = handlers.nonEmpty || forms.nonEmpty)
+      SlackManifest.generate(
+        appName,
+        commandDefs,
+        hasInteractivity = handlers.nonEmpty || forms.nonEmpty,
+        extraBotScopes = idempotency.requiredBotScopes,
+      )
     }
   }
 
@@ -169,10 +175,9 @@ private[slack] class SlackGatewayImpl[F[_]](
     idempotencyKey match {
       case None      => withClient(_.postMessage(channel, text, buildBlocks(text, buttons), threadTs = None))
       case Some(key) =>
-        val channelId = ChannelId(channel)
         for {
           check    <- idempotencyRef.get
-          existing <- check.findExisting(channelId, threadTs = None, key)
+          existing <- check.findExisting(channel, threadTs = None, key)
           result   <- existing match {
                         case Some(found) => monad.unit(found)
                         case None        =>
@@ -191,7 +196,7 @@ private[slack] class SlackGatewayImpl[F[_]](
       case Some(key) =>
         for {
           check    <- idempotencyRef.get
-          existing <- check.findExisting(to.channel, threadTs = Some(to.ts), key)
+          existing <- check.findExisting(to.channel.value, threadTs = Some(to.ts), key)
           result   <- existing match {
                         case Some(found) => monad.unit(found)
                         case None        =>

--- a/chatops4s-slack/src/main/scala/chatops4s/slack/SlackManifest.scala
+++ b/chatops4s-slack/src/main/scala/chatops4s/slack/SlackManifest.scala
@@ -8,6 +8,7 @@ private[slack] object SlackManifest {
       appName: String,
       commands: Map[String, (String, String)],
       hasInteractivity: Boolean,
+      extraBotScopes: Set[String] = Set.empty,
   ): SlackAppManifest = {
     val baseScopes = List(
       "chat:write",
@@ -17,9 +18,12 @@ private[slack] object SlackManifest {
       "reactions:write",
     )
 
-    val botScopes =
+    val withCommands =
       if (commands.nonEmpty) baseScopes :+ "commands"
       else baseScopes
+
+    val extras    = extraBotScopes.toList.sorted.filterNot(withCommands.contains)
+    val botScopes = withCommands ++ extras
 
     val slashCommands =
       if (commands.nonEmpty)

--- a/chatops4s-slack/src/test/resources/snapshots/manifest-minimal.json
+++ b/chatops4s-slack/src/test/resources/snapshots/manifest-minimal.json
@@ -19,7 +19,13 @@
         "chat:write.public",
         "users:read",
         "users:read.email",
-        "reactions:write"
+        "reactions:write",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "mpim:history"
       ]
     }
   },

--- a/chatops4s-slack/src/test/resources/snapshots/manifest-with-buttons.json
+++ b/chatops4s-slack/src/test/resources/snapshots/manifest-with-buttons.json
@@ -19,7 +19,13 @@
         "chat:write.public",
         "users:read",
         "users:read.email",
-        "reactions:write"
+        "reactions:write",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "mpim:history"
       ]
     }
   },

--- a/chatops4s-slack/src/test/resources/snapshots/manifest-with-commands-usage-hint.json
+++ b/chatops4s-slack/src/test/resources/snapshots/manifest-with-commands-usage-hint.json
@@ -28,7 +28,13 @@
         "users:read",
         "users:read.email",
         "reactions:write",
-        "commands"
+        "commands",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "mpim:history"
       ]
     }
   },

--- a/chatops4s-slack/src/test/resources/snapshots/manifest-with-commands.json
+++ b/chatops4s-slack/src/test/resources/snapshots/manifest-with-commands.json
@@ -27,7 +27,13 @@
         "users:read",
         "users:read.email",
         "reactions:write",
-        "commands"
+        "commands",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "mpim:history"
       ]
     }
   },

--- a/chatops4s-slack/src/test/resources/snapshots/manifest-with-explicit-usage-hint.json
+++ b/chatops4s-slack/src/test/resources/snapshots/manifest-with-explicit-usage-hint.json
@@ -28,7 +28,13 @@
         "users:read",
         "users:read.email",
         "reactions:write",
-        "commands"
+        "commands",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "mpim:history"
       ]
     }
   },

--- a/chatops4s-slack/src/test/resources/snapshots/manifest-with-forms.json
+++ b/chatops4s-slack/src/test/resources/snapshots/manifest-with-forms.json
@@ -19,7 +19,13 @@
         "chat:write.public",
         "users:read",
         "users:read.email",
-        "reactions:write"
+        "reactions:write",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "mpim:history"
       ]
     }
   },

--- a/chatops4s-slack/src/test/scala/chatops4s/slack/SlackGatewayTest.scala
+++ b/chatops4s-slack/src/test/scala/chatops4s/slack/SlackGatewayTest.scala
@@ -629,6 +629,22 @@ class SlackGatewayTest extends AnyFreeSpec with Matchers {
         SnapshotTest.testSnapshot(result.renderJson, "snapshots/manifest-with-forms.json")
       }
 
+      "should include scopes required by the registered IdempotencyCheck" in {
+        val customCheck = new IdempotencyCheck[IO] {
+          def findExisting(channel: String, threadTs: Option[Timestamp], key: IdempotencyKey): IO[Option[MessageId]] = IO.pure(None)
+          def recordSent(key: IdempotencyKey, messageId: MessageId): IO[Unit]                                        = IO.unit
+          override val requiredBotScopes: Set[String]                                                                = Set("custom:scope-a", "custom:scope-b")
+        }
+
+        val gateway = createGateway()
+        gateway.withIdempotencyCheck(customCheck).unsafeRunSync()
+
+        val manifest  = gateway.manifest("TestApp").unsafeRunSync()
+        val botScopes = manifest.oauth_config.scopes.flatMap(_.bot).getOrElse(Nil)
+
+        botScopes should contain allOf ("custom:scope-a", "custom:scope-b")
+      }
+
       "modifier should add extra scopes" in {
         val gateway = createGateway()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Slack channel listing capability to query available conversations
  * Introduced channel search functionality to locate channels by name
  * Enhanced bot permissions to include message history access across channels, groups, and direct messages

* **Tests**
  * Added test coverage for bot scope configuration propagation in app manifests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->