### PR TITLE
Extract website version from a file instead of sbt stdout

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -45,8 +45,11 @@ jobs:
       - name: Build
         run: |
           cd ../
-          sbt -batch -error 'print stableVersion' # something unexpected gets added to stdout on first run
-          export CHATOPS4S_VERSION=$(sbt -batch -error 'print stableVersion' | head -n 1)
+          # sbt stdout is not machine-readable (ANSI escapes, progress lines), so the
+          # version is written to a file by the build instead of being parsed from stdout.
+          sbt -batch writeStableVersion
+          export CHATOPS4S_VERSION=$(cat target/stable-version.txt)
+          echo "Building website for chatops4s $CHATOPS4S_VERSION"
           cd website
           yarn build
       - name: Setup Pages

--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,18 @@ stableVersion := {
   else previousStableVersion.value.getOrElse("unreleased")
 }
 
+lazy val stableVersionFile = settingKey[File]("File that writeStableVersion writes to")
+stableVersionFile := (ThisBuild / baseDirectory).value / "target" / "stable-version.txt"
+
+// Writing to a file instead of printing, because sbt's stdout is not machine-readable
+// (ANSI escapes, progress lines, launcher output). Consumed by the website build.
+lazy val writeStableVersion = taskKey[Unit]("Writes stableVersion to stableVersionFile")
+writeStableVersion := {
+  val target = stableVersionFile.value
+  IO.write(target, stableVersion.value)
+  streams.value.log.info(s"Wrote stable version to $target")
+}
+
 lazy val commonSettings = Seq(
   scalaVersion  := "3.8.1",
   scalacOptions ++= Seq(


### PR DESCRIPTION
## Problem

The website deploy workflow read the version by parsing sbt's stdout:

```bash
export CHATOPS4S_VERSION=$(sbt -batch -error 'print stableVersion' | head -n 1)
```

sbt's stdout is not machine-readable. Even with `-error` and `--no-colors`, it emits terminal erase-in-display sequences (`ESC[0J`) from the progress display, plus the `[success] elapsed time` line. `--no-colors` only disables *color* codes, not cursor/erase control codes. The result was a version string like `\e[0J0.2.3`, rendering on the website as `[0J0.2.3`.

## Fix

Stop parsing stdout. A new `writeStableVersion` task writes the value to `target/stable-version.txt`, and the workflow reads that file. The warm-up sbt invocation (which only existed to absorb first-run noise) is gone too.

## Verification

Ran locally against sbt 2.0.1: the file contains exactly `0.2.3` — 5 bytes, no escapes, no trailing newline (`od -c` confirmed). `target` is already gitignored and `fetch-depth: 0` is already set, so dynver can still resolve `previousStableVersion`. `scalafmtSbt` produced no further changes.

Same change applied to `decisions4s` and `workflows4s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved website deployment version handling for more reliable builds.
  * The selected stable version is now recorded and displayed before the website build starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->